### PR TITLE
position: only stop location when suspended

### DIFF
--- a/plugins/position/core_geo_position_info_source.cpp
+++ b/plugins/position/core_geo_position_info_source.cpp
@@ -101,7 +101,7 @@ core::GeoPositionInfoSource::GeoPositionInfoSource(QObject *parent)
 void core::GeoPositionInfoSource::applicationStateChanged()
 {
     Qt::ApplicationState state = qApp->applicationState();
-    if (state != Qt::ApplicationActive) {
+    if (state == Qt::ApplicationSuspended) {
         if (m_applicationActive) {
             int state = m_state;
             stopUpdates();


### PR DESCRIPTION
As a matter of fact, with the other changes in ubuntu-location-service
and in lomiri, applications will not be suspended if they are actively
using the location service. But this change is still needed, because
otherwise it would be the application themselves to stop the location
updates when losing focus.

Fixes: https://github.com/ubports/ubuntu-touch/issues/1067